### PR TITLE
fix: always trim file path

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -182,13 +182,14 @@ pub fn package_contents_list(
         if file_path.ends_with("/pathname") {
             let mut pathname = String::new();
             file.read_to_string(&mut pathname).unwrap();
+            if pathname.contains("\n") {
+                pathname = format!("{}", pathname.split("\n").next().unwrap());
+            }
 
             let mut include = true;
 
             if let Some(dir) = dir {
-                let tmp_file_path = format!("{}", pathname.split("\n").next().unwrap());
-
-                let path = Path::new(&tmp_file_path);
+                let path = Path::new(&pathname);
                 let parent = path.parent().unwrap().to_str().unwrap();
 
                 //println!("Looking for {} in {} || {}", dir, s, parent);


### PR DESCRIPTION
hi,
I didnt really debug the root cause, but the problem I have is that paths are suffixed with `\n00` and they are trimmed  only inside the block `if dir` , which is not the case here for some reason.

I bet this the code can be done better, I'm not Rust pro.

example content from the package where I face the issue:
```
[
["2e51062debed8a3499f79935cdd1711b","Assets/PolygonNatureBiomes\n00"],
["b54a8c94a46b24c499a2ee8c65c5581e","Assets/PolygonNatureBiomes/PNB_Core/Materials/Circle_Transparent_Mat_01.mat\n00"]
]
```